### PR TITLE
CDS hook PlanDefinition for generic response

### DIFF
--- a/input/resources/plandefinition/PlanDefinition-ASLPCrd-GenericResponseCdsHook.json
+++ b/input/resources/plandefinition/PlanDefinition-ASLPCrd-GenericResponseCdsHook.json
@@ -66,9 +66,6 @@
       }
     ]
   },
-  "library": [
-    "http://example.org/sdh/dtr/aslp/Library/ASLPCrdGenericResponseLogic"
-  ],
   "action": [
     {
       "definitionCanonical": "http://example.org/sdh/dtr/aslp/PlanDefinition/ASLPCrd-GenericResponse"


### PR DESCRIPTION
Prior Auth team asked to create a "fake" CDS Hook PlanDefinition to simulate the same RequestGroup structure they are expecting. 

This should be corrected on Prior Auth code to correctly handle a single RequestGroup in the response, but this temporary content change should avoid the problem for now.